### PR TITLE
closes #87

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,7 @@
     "version": "1.0",
 
     "permissions": [
-        "sidePanel",
-        "https://api.languagetool.org/v2/check"
+        "sidePanel"
       ],
 
     "action": {


### PR DESCRIPTION
All I did was remove the link from the permissions. We should just be able to call the API with the full link, I don't think we necessarily need it in the manifest file.